### PR TITLE
Recognize and serve endpoints with metadata properly.

### DIFF
--- a/lib/simple-mock-server.js
+++ b/lib/simple-mock-server.js
@@ -51,19 +51,20 @@ module.exports = {
           var _headers = {};
           fs.readFile(filePath, 'utf8', function (err, data) {
             var content = data;
-            var match = data.match(/\*({[^}]*})\s*\n(.*)/);
+            var match = data.match(/\*({.*})\n([\s\S]*)/);
             if (match) {
               try {
                 var meta = JSON.parse(match[1]);
                 statusCode = meta.code || 200;
-                headers = meta.headers || {};
+                _headers = meta.headers || {};
               } catch (e) {
                 console.log('invalid meta data for ' + filePath + ': ' + e);
               }
               content = match[2];
+              headers["Content-Length"] = content.size || 0;
             }
             for (var name in _headers) {
-              headers[name] = _headers[_name];
+              headers[name] = _headers[name];
             }
             response.writeHead(statusCode, headers);
             response.write(content);


### PR DESCRIPTION
Remove an unused/misused variable, moving an underscore which was
probably misplaced along the way.

Use a better regex which recognizes metadata lines which contain a
header dictionary.

Adjust the Content-length header based on the length of the parsed
content, not the entire file.